### PR TITLE
added base template with Xenotype styling and placeholder routes

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template
+from flask_login import login_required, current_user
 
 main = Blueprint('main', __name__)
 
@@ -6,3 +7,16 @@ main = Blueprint('main', __name__)
 
 def lobby():
     return render_template('lobby.html')
+
+@main.route('/scenarios')
+def scenarios():
+    return render_template('scenarios.html')
+
+@main.route('/leaderboard')
+def leaderboard():
+    return render_template('leaderboard.html')
+
+@main.route('/profile/<username>')
+@login_required
+def profile(username):
+    return render_template('profile.html', username=username)

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,0 +1,185 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Orbitron:wght@400;700;900&display=swap');
+
+:root {
+	--xt-bg: #020c04;
+	--xt-bg2: #050f07;
+	--xt-bg3: #071509;
+	--xt-green: #00ff41;
+	--xt-green2: #00cc33;
+	--xt-green3: #006611;
+	--xt-green4: #003308;
+	--xt-text: #b8ffb8;
+	--xt-text2: #7acc7a;
+	--xt-text3: #4a8a4a;
+	--xt-red: #ff2222;
+	--xt-amber: #ffcc00;
+	--xt-border: #1a4a1a;
+	--mono: 'JetBrains Mono', monospace;
+	--orb: 'Orbitron', monospace;
+}
+
+* {
+	* box-sizing: border-box;
+	* margin: 0;
+	* padding: 0;
+}
+
+body {
+	background: var(--xt-bg);
+	color: var(--xt-text);
+	font-family: var(--mono);
+	min-height: 100vh;
+}
+
+/* NAV */
+.xt-nav {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 24px;
+	border-bottom: 1px solid var(--xt-border);
+	background: var(--xt-bg2);
+	position: sticky;
+	top: 0;
+	z-index: 100;
+}
+
+.xt-logo {
+	font-family: var(--orb);
+	font-size: 18px;
+	font-weight: 900;
+	color: var(--xt-green);
+	letter-spacing: 4px;
+	text-decoration: none;
+}
+
+.xt-logo span {
+	color: var(--xt-text3);
+}
+
+.xt-nav-links {
+	display: flex;
+	gap: 4px;
+}
+
+.xt-nav-link {
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--xt-text3);
+	cursor: pointer;
+	padding: 6px 12px;
+	border: 1px solid transparent;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	text-decoration: none;
+	transition: all 0.15s;
+}
+
+.xt-nav-link:hover {
+	color: var(--xt-green);
+	border-color: var(--xt-border);
+	background: var(--xt-green4);
+}
+
+main {
+	max-width: 1100px;
+	margin: 0 auto;
+	padding: 32px 24px;
+}
+
+.flash-messages{
+	margin-bottom: 20px;
+}
+
+.flash {
+	background: var(--xt-green4);
+	border: 1px solid var(--xt-green3);
+	color: var(--xt-green);
+	padding: 10px 16px;
+	font-size: 12px;
+	letter-spacing: 1px;
+	margin-bottom: 8px;
+}
+
+.btn {
+	font-family: var(--mono);
+	font-size: 11px;
+	cursor: pointer;
+	letter-spacing: 2px;
+	text-transform: uppercase;
+	padding: 10px 20px;
+	border: 1px solid var(--xt-green3);
+	color: var(--xt-green);
+	background: var(--xt-green4);
+	transition: all 0.15s;
+	text-decoration: none;
+	display: inline-block;
+}
+
+.btn:hover {
+	background: var(--xt-green3);
+	border-color: var(--xt-green);
+}
+
+input[type=text],
+input[type=password],
+input[type=email],
+select,
+textarea {
+	width: 100%;
+	background: var(--xt-bg3);
+	border: 1px solid var(--xt-border);
+	color: var(--xt-text);
+	font-family: var(--mono);
+	font-size: 13px;
+	padding: 10px 14px;
+	outline: none;
+	transition: border-color 0.15s;
+	margin-bottom: 14px;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+	border-color: var(--xt-green3);
+}
+
+input::placeholder {
+	color: var(--xt-text3);
+}
+
+label {
+	font-size: 11px;
+	color: var(--xt-text3);
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	display: block;
+	margin-bottom: 6px;
+}
+
+.card {
+	background: var(--xt-bg2);
+	border: 1px solid var(--xt-border);
+	padding: 20px;
+}
+
+h1, h2, h3 {
+	font-family: var(--orb);
+	color: var(--xt-green);
+	letter-spacing: 3px;
+	text-transform: uppercase;
+	margin-bottom: 16px;
+}
+
+h1 { font-size: 24px; }
+h2 { font-size: 18px; }
+h3 { font-size: 14px; }
+
+a {
+	color: var(--xt-green2);
+	text-decoration: none;
+}
+
+a:hover {
+	color: var(--xt-green);
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,10 +3,47 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Xenotype</title>
+	<title>{% block title %}Xenotype{% endblock %}</title>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+	<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
 <body>
-	{% block content %}{% endblock %}
+	<nav class="xt-nav">
+		<div class="xt-logo">XENO<span>TYPE</span></div>
+		<div class="xt-nav-links">
+			<a class="xt-nav-link" href="{{ url_for('main.lobby') }}">Lobby</a>
+			<a class="xt-nav-link" href="{{ url_for('main.scenarios') }}">Scenarios</a>
+			<a class="xt-nav-link" href="{{ url_for('main.leaderboard') }}">Leaderboard</a>
+			{% if current_user.is_authenticated %}
+				<a class="xt-nav-link" href="{{ url_for('main.profile', username=current_user.username) }}">Profile</a>
+				<a class="xt-nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
+			{% else %}
+				<a class="xt-nav-link" href="{{ url_for('auth.login') }}">Login</a>
+				<a class="xt-nav-link" href="{{ url_for('auth.register') }}">Register</a>
+			{% endif %}
+		</div>
+	</nav>
+
+	<main>
+		{% with messages = get_flashed_messages() %}
+			{% if messages %}
+				<div class="flash-messages">
+					{% for message in messages %}
+						<div class="flash">{{ message }}</div>
+					{% endfor %}
+				</div>
+			{% endif %}
+		{% endwith %}
+
+		{% block content %}{% endblock %}
+
+	</main>
+
+	<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+
+	{% block scripts %}{% endblock %}
+
 </body>
 </html>

--- a/app/templates/leaderboard.html
+++ b/app/templates/leaderboard.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Leaderboard</h1>
+<p style="color: var(--xt-text3);">Coming soon.</p>
+{% endblock %}

--- a/app/templates/lobby.html
+++ b/app/templates/lobby.html
@@ -1,4 +1,11 @@
 {% extends "base.html" %}
+{% block title %}Xenotype — Mission Control{% endblock %}
 {% block content %}
-<h1>Xenotype is alive</h1>
+<div style="margin-bottom: 32px;">
+	<p style="font-size: 11px; color: var(--xt-text3); letter-spacing: 2px; text-transform: uppercase; margin-bottom: 8px;">// MISSION CONTROL</p>
+	<h1>Welcome, Agent</h1>
+	<p style="color: var(--xt-text3); font-size: 13px;">Select a mission to begin transmission.</p>
+</div>
+
+<a href="{{ url_for('main.scenarios') }}" class="btn">Browse Scenarios</a>
 {% endblock %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Profile — {{ username }}</h1>
+<p style="color: var(--xt-text3);">Coming soon.</p>
+{% endblock %}

--- a/app/templates/scenarios.html
+++ b/app/templates/scenarios.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Scenarios</h1>
+<p style="color: var(--xt-text3);">Coming soon.</p>
+{% endblock %}
+
+


### PR DESCRIPTION
Adds global Xenotype visual design and missing route stubs.

- base.html with green/black CRT terminal aesthetic
- JetBrains Mono and Orbitron fonts loaded
- Sticky nav with login/logout conditional display
- main.css with CSS variables, nav, button, form and card styles
- Placeholder routes and templates for scenarios, leaderboard and profile
- main.js stub added to static/js