### PR TITLE
Makes the logo and title a clickable link back to the Lobby

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 	<nav class="xt-nav">
-		<div class="xt-logo" style="display:flex;align-items:center;gap:8px;">
+	<a href="{{ url_for('main.lobby') }}" class="xt-logo" style="display:flex;align-items:center;gap:8px;text-decoration:none;">	
 			<img src="{{ url_for('static', filename='Logo.png')}}" style="width:28px;height:28px;object-fit:contain;image-rendering:pixelated;">
 			XENO<span>TYPE</span>
 		</div>


### PR DESCRIPTION
Wraps the nav logo and XENOTYPE text in an anchor tag linking to the lobby page, following standard web navigation conventions.

Changes:
- xt-logo div replaced with anchor tag
- Clicking logo or XENOTYPE text returns user to lobby from any page