### PR TITLE
Fixes handle for 413 file too large error gracefully with flash message

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,6 +55,13 @@ def create_app(test_config=None):
         exist_ok=True
     )
 
+    from flask import flash, redirect, request, url_for
+
+    @app.errorhandler(413)
+    def too_large(e):
+        flash('File too large. Maximum size is 2 MB. Please choose a smaller image.')
+        return redirect(request.referrer or url_for('main.lobby'))
+
     return app
 
 


### PR DESCRIPTION
Fixes raw 413 error page when uploading a profile photo over 2MB.

Changes:
- Added 413 error handler in app/__init__.py
- Handler flashes a user-friendly error message
- Redirects back to the profile page instead of showing raw error

Closes issue #77 