### PR TITLE
Quickfix for overflowing username error on the lobby screen

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -534,6 +534,8 @@ label {
 
 .lobby-briefing {
   align-self: start;
+  min-width: 0;
+  max-width: 100%;
   background:
     linear-gradient(135deg, rgba(0, 255, 76, 0.08), transparent 38%),
     var(--panel);
@@ -548,10 +550,17 @@ label {
   font-size: clamp(38px, 5.8vw, 68px);
   line-height: 0.98;
   margin-bottom: 18px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .lobby-briefing h1 span {
   color: var(--green-soft);
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .lobby-copy {


### PR DESCRIPTION
fixed error where if a username was long enough it would overflow past the box